### PR TITLE
Jenkins BlueOcean support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jenkins2-api (1.0.14)
+    jenkins2-api (1.0.15)
       thor (~> 0.19)
 
 GEM
@@ -49,7 +49,7 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    thor (0.19.4)
+    thor (0.20.3)
     tilt (2.0.7)
     unicode-display_width (1.2.1)
     webmock (3.0.1)
@@ -70,4 +70,4 @@ DEPENDENCIES
   webmock (>= 3.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,11 +18,11 @@ GEM
       ast (~> 2.2)
     powerpack (0.1.1)
     public_suffix (2.0.5)
-    rack (1.6.5)
+    rack (1.6.12)
     rack-protection (1.5.3)
       rack
     rainbow (2.2.1)
-    rake (12.0.0)
+    rake (12.3.3)
     rdoc (5.1.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -62,7 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   jenkins2-api!
-  rake (>= 12.0)
+  rake (~> 12, >= 12.3.3)
   rdoc (>= 5.1)
   rspec (>= 3.5)
   rubocop (>= 0.48)

--- a/jenkins2-api.gemspec
+++ b/jenkins2-api.gemspec
@@ -21,11 +21,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'thor', '~> 0.19'
 
-  s.add_development_dependency 'rake', '>= 12.0'
+  s.add_development_dependency 'rake', '>= 12.3.3', '~> 12'
   s.add_development_dependency 'rdoc', '>= 5.1'
   s.add_development_dependency 'rspec', '>= 3.5'
   s.add_development_dependency 'webmock', '>= 3.0'
   s.add_development_dependency 'sinatra', '>= 1.4'
   s.add_development_dependency 'rubocop', '>= 0.48'
 end
-

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -64,7 +64,7 @@ module Jenkins2API
     # ==== Params:
     # +method+:: +:post+ or +:get+
     # +path+:: Path to the Jenkins resource (e.g.: +/job/my-job/+)
-    # +response_type+:: +:json+ or +:raw+
+    # +response_type+:: +:json+, +:xml+ or +:raw+
     # +opts+:: sym options to pass to the endpoint. Applicable only if +:post+
     def api_request(method, path, response_type = :json, **opts)
       req = new_request(method, path, response_type, opts)
@@ -85,10 +85,11 @@ module Jenkins2API
     # Creates a new request for the API call
     # with default and required values
     def new_request(method, path, response_type, **opts)
-      response_type = :json unless %i[json raw].include?(response_type)
+      response_type = :json unless %i[json raw xml].include?(response_type)
 
       parts = [@server, URI.escape(path)]
       parts << 'api/json' if response_type == :json
+      parts << 'api/xml' if response_type == :xml
       uri = URI(File.join(parts))
       uri.query = URI.encode_www_form(opts)
 

--- a/lib/endpoints/build.rb
+++ b/lib/endpoints/build.rb
@@ -28,7 +28,7 @@ module Jenkins2API
       # +name+:: Name of the Job
       # +build_id+:: ID of the build
       def test_results(name, build_id)
-        @client.api_request(:get, "/job/#{name}/#{build_id}/testReport")
+        @client.api_request(:get, "/job/#{name}/#{build_id}/testReport", :xml)
       end
 
       # Get +console log+ for a specific build as text

--- a/lib/endpoints/job.rb
+++ b/lib/endpoints/job.rb
@@ -31,6 +31,16 @@ module Jenkins2API
         @client.api_request(:get, "/job/#{name}")['builds']
       end
 
+      # Get all available sub-jobs for a specific job
+      #
+      # ==== Params:
+      # +name+:: Name of the Job
+      #
+      # Returns with an array of jobs
+      def jobs(name)
+        @client.api_request(:get, "/job/#{name}")['jobs']
+      end
+
       # Trigger a build on a specific job
       #
       # ==== Params:


### PR DESCRIPTION
Supersedes #12 

* Support BlueOcean jobs, which are presented as children of other jobs that correspond to repository names
* Support XML for downloading test reports